### PR TITLE
Scrapper configuration files

### DIFF
--- a/app/scrappers.toml
+++ b/app/scrappers.toml
@@ -1,0 +1,52 @@
+# Scrapper configuration file.
+#
+# You can define new scrappers here by using the pre-defined templates
+# of other imageboards. Parameters are as follows:
+#
+#  The imageboard name Will be used in the database, actor system, logs and other things
+#  and thus must be unique, you can think of it as the scrapper ID
+#   [imageboard-name]
+#
+#  Type is the pre-defined template the scrapper will use
+#   type = "old-danbooru"
+#         "new-danbooru"
+#         "moebooru"
+#
+#  Base URL is the URL all requests by the scrapper will be made to,
+#  it SHOULD NOT include a trailing slash, as this can cause errors
+#   base-url = "https://somebooru.org"
+#
+#  Optionally you can disable the scrapper altogether, then it will not be started at all
+#   enabled = false
+
+# Old-danbooru-like
+
+[safebooru]
+type = "old-danbooru"
+base-url = "https://safebooru.org"
+
+[furrybooru]
+type = "old-danbooru"
+base-url = "http://furry.booru.org"
+
+# New-danbooru-style
+
+# Errors out after the 1000th page (API limitation)
+[danbooru]
+type = "new-danbooru"
+base-url = "https://danbooru.donmai.us"
+
+# Moebooru-like
+
+[konachan]
+type = "moebooru"
+base-url = "https://konachan.com"
+
+[yandere]
+type = "moebooru"
+base-url = "https://yande.re"
+
+[sakugabooru]
+type = "moebooru"
+base-url = "https://sakugabooru.com"
+enabled = false

--- a/app/scrappers/GenericScrapper.scala
+++ b/app/scrappers/GenericScrapper.scala
@@ -31,7 +31,8 @@ abstract class GenericScrapper(
   name: String,
   baseUrl: String,
   favicon: String
-)(implicit ws: WSClient,
+)(
+  implicit ws: WSClient,
   mongo: Mongo,
   ec: ExecutionContext,
 ) extends Actor {

--- a/app/scrappers/GenericScrapper.scala
+++ b/app/scrappers/GenericScrapper.scala
@@ -27,12 +27,14 @@ import org.mongodb.scala.model.Filters._
  * You need to override some things and you get a functional scrapper
  * for most of the imageboards.
  */
-abstract class GenericScrapper
-  (
-    implicit ws: WSClient,
-    mongo: Mongo,
-    ec: ExecutionContext,
-  ) extends Actor {
+abstract class GenericScrapper(
+  name: String,
+  baseUrl: String,
+  favicon: String
+)(implicit ws: WSClient,
+  mongo: Mongo,
+  ec: ExecutionContext,
+) extends Actor {
 
   /** Defines the structure of the image returned by the imageboard.
     *
@@ -43,26 +45,11 @@ abstract class GenericScrapper
     */
   type ScrapperImage
 
-  /** Name of the scrapper and/or the imageboard.
-    *
-    * This name is used for storing the data in MongoDB
-   */
-  val name: String
-
-  /** Base imageboard URL from which others are derived.
-    *
-    * The URL must not include a trailing slash
-    */
-  val baseUrl: String
-
   /** The string that needs to be added to the base URL to access the API.
     *
     * The URL must not include a trailing slash
    */
   val apiAddition: String
-
-  /** The imageboard favicon file relative to the [[baseUrl]] */
-  val favicon: String = "favicon.ico"
 
   /** Maximum number of threads to fetch pages concurrenyly */
   val maxPageFetchingConcurrency: Int = 5

--- a/app/scrappers/GenericScrapper.scala
+++ b/app/scrappers/GenericScrapper.scala
@@ -60,7 +60,7 @@ abstract class GenericScrapper(
   /** Each page's size */
   val pageSize = 100
 
-  val logger = Logger(this.getClass)
+  val logger = Logger(self.path.name)
 
   /** JSON formatter for the image. */
   implicit val imageFormat: OFormat[ScrapperImage]

--- a/app/scrappers/Moebooru.scala
+++ b/app/scrappers/Moebooru.scala
@@ -7,12 +7,15 @@ import play.api.libs.json._
 
 import soxx.mongowrapper._
 
-abstract class MoebooruScrapper
-  (
-    implicit ws: WSClient,
-    mongo: Mongo,
-    ec: ExecutionContext
-  ) extends GenericScrapper {
+class MoebooruScrapper(
+  name: String,
+  baseUrl: String,
+  favicon: String
+)(
+  implicit ws: WSClient,
+  mongo: Mongo,
+  ec: ExecutionContext
+) extends GenericScrapper(baseUrl, favicon, name) {
 
   case class MoebooruImage(
     id: Int,
@@ -81,38 +84,4 @@ abstract class MoebooruScrapper
       )
     )
   }
-}
-
-class KonachanScrapper
-  (
-    implicit ws: WSClient,
-    mongo: Mongo,
-    ec: ExecutionContext
-  ) extends MoebooruScrapper {
-
-  override val baseUrl = "https://konachan.com"
-  override val name = "konachan"
-}
-
-class YandereScrapper
-  (
-    implicit ws: WSClient,
-    mongo: Mongo,
-    ec: ExecutionContext
-  ) extends MoebooruScrapper {
-
-  override val baseUrl = "http://yande.re"
-  override val name = "yandere"
-}
-
-/* This one is mostly videos but it's still moebooru */
-class SakugabooruScrapper
-  (
-    implicit ws: WSClient,
-    mongo: Mongo,
-    ec: ExecutionContext
-  ) extends MoebooruScrapper {
-
-  override val baseUrl = "https://www.sakugabooru.com"
-  override val name = "sakugabooru"
 }

--- a/app/scrappers/NewDanbooru.scala
+++ b/app/scrappers/NewDanbooru.scala
@@ -7,12 +7,15 @@ import play.api.libs.json._
 
 import soxx.mongowrapper._
 
-abstract class NewDanbooruScrapper
-  (
-    implicit ws: WSClient,
-    mongo: Mongo,
-    ec: ExecutionContext
-  ) extends GenericScrapper {
+class NewDanbooruScrapper(
+  name: String,
+  baseUrl: String,
+  favicon: String
+)(
+  implicit ws: WSClient,
+  mongo: Mongo,
+  ec: ExecutionContext
+) extends GenericScrapper(baseUrl, favicon, name) {
 
   case class NewDanbooruImage(
     id: Int,
@@ -87,16 +90,4 @@ abstract class NewDanbooruScrapper
       )
     } else { None }
   }
-}
-
-// Errors out on 1000th+ page
-class DanbooruScrapper
-  (
-    implicit ws: WSClient,
-    mongo: Mongo,
-    ec: ExecutionContext
-  ) extends NewDanbooruScrapper {
-
-  override val baseUrl = "https://danbooru.donmai.us"
-  override val name = "danbooru"
 }

--- a/app/scrappers/OldDanbooru.scala
+++ b/app/scrappers/OldDanbooru.scala
@@ -7,12 +7,15 @@ import play.api.libs.json._
 
 import soxx.mongowrapper._
 
-abstract class OldDanbooruScrapper
-  (
-    implicit ws: WSClient,
-    mongo: Mongo,
-    ec: ExecutionContext
-  ) extends GenericScrapper {
+class OldDanbooruScrapper(
+  name: String,
+  baseUrl: String,
+  favicon: String
+)(
+  implicit ws: WSClient,
+  mongo: Mongo,
+  ec: ExecutionContext
+) extends GenericScrapper(baseUrl, favicon, name) {
 
   case class OldDanbooruImage(
     id: Int,
@@ -76,27 +79,4 @@ abstract class OldDanbooruScrapper
       )
     )
 
-}
-
-class SafebooruScrapper
-  (
-    implicit ws: WSClient,
-    mongo: Mongo,
-    ec: ExecutionContext
-  ) extends OldDanbooruScrapper {
-
-  override val baseUrl = "https://safebooru.org"
-  override val name = "safebooru"
-}
-
-class FurrybooruScrapper
-  (
-    implicit ws: WSClient,
-    mongo: Mongo,
-    ec: ExecutionContext
-  ) extends OldDanbooruScrapper {
-
-  // Furrybooru doesnt support https
-  override val baseUrl = "http://furry.booru.org"
-  override val name = "furrybooru"
 }

--- a/app/scrappers/ScrapperConfig.scala
+++ b/app/scrappers/ScrapperConfig.scala
@@ -1,0 +1,8 @@
+package soxx.scrappers
+
+case class ScrapperConfig(
+  `type`: String,
+  `base-url`: String,
+  favicon: String = "favicon.ico",
+  enabled: Boolean = true
+)

--- a/app/scrappers/ScrapperSupervisor.scala
+++ b/app/scrappers/ScrapperSupervisor.scala
@@ -47,6 +47,7 @@ class ScrapperSupervisor @Inject()
                   case "old-danbooru" => classOf[OldDanbooruScrapper]
                   case "new-danbooru" => classOf[NewDanbooruScrapper]
                   case "moebooru" => classOf[MoebooruScrapper]
+                  case i => throw new IllegalArgumentException(f"Unknown type used for imageboard $name: $i")
                 }
 
                 context.actorOf(

--- a/app/scrappers/ScrapperSupervisor.scala
+++ b/app/scrappers/ScrapperSupervisor.scala
@@ -5,6 +5,7 @@ import scala.util._
 
 import akka.actor._
 import scala.concurrent._
+import play.api.Configuration
 import play.api.libs.ws._
 import play.api.inject.ApplicationLifecycle
 import play.api.Logger
@@ -22,7 +23,8 @@ class ScrapperSupervisor @Inject()
     implicit ec: ExecutionContext,
     ws: WSClient,
     mongo: Mongo,
-    lifecycle: ApplicationLifecycle
+    lifecycle: ApplicationLifecycle,
+    appConfig: Configuration
   ) extends Actor {
 
   override val supervisorStrategy = (new StoppingSupervisorStrategy).create()
@@ -33,9 +35,9 @@ class ScrapperSupervisor @Inject()
    * Additional documentation about defining scrappers can be
    * found in the aforementioned file.
    */
-  def startScrappersFromConfig() {
+  def startScrappersFromConfig(configPath: String = appConfig.get[String]("soxx.scrappers.configFile")) {
     Try {
-      val cfgFile = scala.io.Source.fromFile("scrappers.toml")
+      val cfgFile = scala.io.Source.fromFile(configPath)
       try cfgFile.mkString finally cfgFile.close
     } match {
       case Success(configStr) =>

--- a/app/scrappers/ScrapperSupervisor.scala
+++ b/app/scrappers/ScrapperSupervisor.scala
@@ -49,7 +49,9 @@ class ScrapperSupervisor @Inject()
                   case "old-danbooru" => classOf[OldDanbooruScrapper]
                   case "new-danbooru" => classOf[NewDanbooruScrapper]
                   case "moebooru" => classOf[MoebooruScrapper]
-                  case i => throw new IllegalArgumentException(f"Unknown type used for imageboard $name: $i")
+                  case i =>
+                    logger.error(f"Unknown type used for imageboard $name: $i, skipping")
+                    return
                 }
 
                 context.actorOf(

--- a/app/scrappers/ScrapperSupervisor.scala
+++ b/app/scrappers/ScrapperSupervisor.scala
@@ -64,7 +64,7 @@ class ScrapperSupervisor @Inject()
               Props(
                 scrapperType,
                 name,
-                config.`base-url`,
+                config.`base-url`.stripSuffix("/"), // Remove the trailing slash
                 config.favicon,
                 implicitly[WSClient],
                 implicitly[Mongo],

--- a/build.sbt
+++ b/build.sbt
@@ -24,11 +24,14 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
+  guice,
+
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
   ws,
 
-  guice,
 
   "org.mongodb.scala" %% "mongo-scala-driver" % "2.2.1",
-  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.0"
+  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.0",
+
+  "tech.sparse" %%  "toml-scala" % "0.1.2-SNAPSHOT"
 )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,5 +1,7 @@
 # https://www.playframework.com/documentation/latest/Configuration
 
+soxx.scrappers.configFile = "scrappers.toml"
+
 play.filters.disabled = [
   play.filters.headers.SecurityHeadersFilter,
   play.filters.hosts.AllowedHostsFilter

--- a/scrappers.toml
+++ b/scrappers.toml
@@ -1,0 +1,30 @@
+# Old-danbooru-like
+
+[safebooru]
+type = "old-danbooru"
+base-url = "https://safebooru.org"
+
+[furrybooru]
+type = "old-danbooru"
+base-url = "http://furry.booru.org"
+
+# New-danbooru-style
+
+[danbooru]
+type = "new-danbooru"
+base-url = "https://danbooru.donmai.us"
+
+# Moebooru-like
+
+[konachan]
+type = "moebooru"
+base-url = "https://konachan.com"
+
+[yandere]
+type = "moebooru"
+base-url = "https://yande.re"
+
+[sakugabooru]
+type = "moebooru"
+base-url = "https://sakugabooru.com"
+enabled = false


### PR DESCRIPTION
Implement scrapper configuration via a TOML file and remove all the subclasses that were used as these imageboards.

The startup process is also made to work with this, so names now need not to be dublicated on initialization.

Abstract classes that represent imageboard types were made concrete since they're now used in place of subclasses.