### PR TITLE
Advanced search

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Some important things include:
 - [x] S3 integration
 - Searching
   - [x] Basic image search by tags and tag regular expressions
-  - [ ] Advanced image search with grouping, AND, OR
-  - [ ] Similar image search
+  - [x] Advanced image search with grouping, AND, OR
+  - [x] Similar image search
   - [ ] Searching images by their properties (width, height, rating)
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Some important things include:
 - Searching
   - [x] Basic image search by tags and tag regular expressions
   - [ ] Advanced image search with grouping, AND, OR
-  - [ ] Similiar image search
+  - [ ] Similar image search
   - [ ] Searching images by their properties (width, height, rating)
 
 ## Contributions

--- a/app/controllers/APIv1Controller.scala
+++ b/app/controllers/APIv1Controller.scala
@@ -128,8 +128,7 @@ class APIv1Controller @Inject()
             case Some(image) =>
               imageCollection
                 .aggregate(Seq(
-                  // This makes MongoDB use the index, otherwise it'd use COLLSCAN
-                  sort(descending("_id")),
+                  `match`(not(equal("_id", image._id))),
                   unwind("$tags"),
                   `match`(in("tags", image.tags:_*)),
                   group("$_id", sum("count", 1)),

--- a/app/controllers/APIv1Controller.scala
+++ b/app/controllers/APIv1Controller.scala
@@ -140,13 +140,13 @@ class APIv1Controller @Inject()
                     )
                   )),
                   sort(descending("score")),
-                  skip(offset),
-                  limit(resultLimit),
                   // Because the document is not what it was and only includes an ID and a similiarity value, we now retreive the whole document again
                   lookup(from = "images", localField = "_id", foreignField = "_id", as = "doc"),
                   replaceRoot(
                     equal("$arrayElemAt", Seq("$doc", 0))
-                  )
+                  ),
+                  skip(offset),
+                  limit(resultLimit)
                 )).toFuture.map { imgs =>
                   Ok(Json.obj(
                     "ok" -> true,

--- a/app/controllers/APIv1Controller.scala
+++ b/app/controllers/APIv1Controller.scala
@@ -105,7 +105,7 @@ class APIv1Controller @Inject()
     }
   }
 
-  def similiar_images(id: String, offset: Int, _resultLimit: Int) = Action.async { implicit request: Request[AnyContent] =>
+  def similar_images(id: String, offset: Int, _resultLimit: Int) = Action.async { implicit request: Request[AnyContent] =>
     import org.bson.types.ObjectId
     import org.mongodb.scala._
     import org.mongodb.scala.bson.{ Document => _, _ }
@@ -139,7 +139,7 @@ class APIv1Controller @Inject()
                     )
                   )),
                   sort(descending("score")),
-                  // Because the document is not what it was and only includes an ID and a similiarity value, we now retreive the whole document again
+                  // Because the document is not what it was and only includes an ID and a similarity value, we now retreive the whole document again
                   lookup(from = "images", localField = "_id", foreignField = "_id", as = "doc"),
                   replaceRoot(
                     equal("$arrayElemAt", Seq("$doc", 0))

--- a/app/search/QueryParser.scala
+++ b/app/search/QueryParser.scala
@@ -1,35 +1,65 @@
 package soxx.search
 
 import scala.language.postfixOps
+
 import scala.util.matching.Regex
 
 import scala.util.parsing.combinator._
 
-abstract class QueryTag
-case class FullTag(value: String) extends QueryTag
-case class ExcludeTag(value: String) extends QueryTag
+sealed abstract class QueryTag
+
+case class SimpleTag(value: String) extends QueryTag
+case class ExactTag(value: String) extends QueryTag
 case class RegexTag(value: Regex) extends QueryTag
+
+case class TagAND(left: QueryTag, right: QueryTag) extends QueryTag
+case class TagOR(left: QueryTag, right: QueryTag) extends QueryTag
+case class TagNOT(value: QueryTag) extends QueryTag
+
+case class TagGroup(value: List[QueryTag]) extends QueryTag
 
 /** Search query parser.
   *
-  * Parses search queries separated by spaces, it recognizes full tags,
-  * tag excludes and regex tags with a special syntax regex~regex goes here!~.
-  * Note the the previous makes tildes otherwise unusable in regular expressions. I suppose this
-  * issue will be addressed in the future.
+  * This parser is used to parse the search query into tags, which can include the following:
+  * - a simple tag: anything that does not contain "(", ")", "!", "|", "&" or "\" can be considered a simple tag
+  * - an exact tag: a quoted tag that can contain any symbols including an escaped quote symbol (so, for example, "\"_\"" means "_")
+  * - logical NOT marker: if any kind of tag is preceeded with an exclamation mark, it's meaning is inverted (logical NOT)
+  * - tag group: a list of tags that is surrounded by parenthesis to group them together
+  * - logical operators: && and || can be used to construct complex logical operations, both of them are left associative
+  * - regex tag: a tag that is marked with REGEX(the actual regex).
+  *              It can contain a ) but it must be escaped as "\)", it will then be transformed into ).
   */
-object QueryParser extends RegexParsers {
+object QueryParser extends RegexParsers with PackratParsers {
   override def skipWhitespace = true
 
-  def fullTag: Parser[FullTag] = """[^\s\-]+""".r ^^ { x => FullTag(x.toString) }
-  def excludeTag: Parser[QueryTag] = "-" ~> fullTag ^^ {
-    case FullTag(v) => ExcludeTag(v)
+  // Basically, include anything except some special symbols
+  def simpleTag: Parser[SimpleTag] = """[^\s\!\(\)\"\\\&\|]+""".r ^^ { SimpleTag(_) }
+
+  // This will match anything quoted and also allow quoting with \"
+  // In the final tag, \" will be replaced with "
+  def exactTag: Parser[ExactTag] = "\"" ~> """((\\\")|[^\"])+""".r <~ "\"" ^^ { t => ExactTag(t.replace("\\\"", "\"")) }
+
+  // Regular expression tag, ) can be escaped \\) (double backslash paren) because \) is a valid use case for tags.
+  // So, for example, to search something with a closing paren one would need to write REGEX(\(.+\\\\\))
+  def regexTag: Parser[RegexTag] =  "REGEX(" ~> """((\\\))|[^\)])+""".r <~ ")" ^^ { t =>
+    RegexTag(new Regex(
+      t.replace("""\)""", """)""")
+    ))
   }
 
-  def regexTag: Parser[QueryTag] = "regex~" ~> "[^~]+".r <~ "~"  ^^ { case x =>
-    RegexTag(new Regex(x))
-  }
+  def not: Parser[QueryTag] = "!" ~> aTag ^^ { TagNOT(_) }
 
-  def theQueryParser = (regexTag | excludeTag | fullTag)*
+  def groupedTags: PackratParser[TagGroup] = "(" ~> aTag.+ <~ ")" ^^ { TagGroup(_) }
 
-  def parseQuery(theQuery: String) = parse(theQueryParser, theQuery)
+  lazy val logic: PackratParser[QueryTag] = chainl1(
+    withoutLogic,
+    ( "&&" ^^^ { TagAND(_, _) } ) | ( "||" ^^^ { TagOR(_, _) } )
+  )
+
+  lazy val withoutLogic = groupedTags | regexTag | exactTag | not | simpleTag
+  lazy val aTag = logic | withoutLogic
+
+  lazy val severalTags: PackratParser[List[QueryTag]] = aTag*
+
+  def parseQuery(theQuery: String) = parse(phrase(severalTags), theQuery)
 }

--- a/assets/vue/Admin.vue
+++ b/assets/vue/Admin.vue
@@ -111,8 +111,9 @@
              }
          };
 
-         fetch("/api/v1/imboard_info").then(res => {
-             res.json().then(imboard_list => {
+         fetch("/api/v1/imboard_info")
+             .then(res => res.json())
+             .then(imboard_list => {
                  this.imboards = imboard_list;
 
                  _.map(imboard_list, (imboard) => {
@@ -120,8 +121,6 @@
                      ws.send(JSON.stringify({tp: "imboard-scrapper-status", imboard: imboard._id}))
                  });
              });
-         });
-
      },
 
      methods: {

--- a/assets/vue/ImageInfo.vue
+++ b/assets/vue/ImageInfo.vue
@@ -42,7 +42,7 @@
 
         <div class="container-fluid">
             <div class="row">
-                <div class="card col-lg-6 col-xl-4" v-for="simage in similiarImages" v-bind:key="simage._id">
+                <div class="card col-lg-6 col-xl-4" v-for="simage in similarImages" v-bind:key="simage._id">
                     <!-- Hacky but works! Looks beter then object-fit too  -->
                     <!-- Just using the first "from" may not be the best idea -->
                     <a v-bind:href="`/image/${simage._id}`">
@@ -52,8 +52,8 @@
             </div>
         </div>
 
-        <button class="btn btn-primary mx-auto" style="width: 15em;" v-bind:style="{ display: showMoreSimiliarButtonVisible ? 'block' : 'none' }" v-on:click="loadMoreSimiliar">
-            Similiar images
+        <button class="btn btn-primary mx-auto" style="width: 15em;" v-bind:style="{ display: showMoreSimilarButtonVisible ? 'block' : 'none' }" v-on:click="loadMoreSimilar">
+            Similar images
         </button>
     </div>
 </template>
@@ -78,8 +78,8 @@
 
      data() {
          return {
-             similiarImages: [],
-             showMoreSimiliarButtonVisible: true
+             similarImages: [],
+             showMoreSimilarButtonVisible: true
          };
      },
 
@@ -121,18 +121,18 @@
              return he.decode(tag);
          },
 
-         loadMoreSimiliar() {
-             let url = new URI(`/api/v1/similiar_images/${this.image._id}`);
-             url.addQuery("offset", this.similiarImages.length);
+         loadMoreSimilar() {
+             let url = new URI(`/api/v1/similar_images/${this.image._id}`);
+             url.addQuery("offset", this.similarImages.length);
 
              fetch(url)
                  .then(resp => resp.json())
                  .then(jsonResp => {
-                     this.similiarImages = _.concat(this.similiarImages, jsonResp.images);
+                     this.similarImages = _.concat(this.similarImages, jsonResp.images);
 
                      // FIXME: make configurable
                      if (jsonResp.images.length < 25) {
-                         this.showMoreSimiliarButtonVisible = false;
+                         this.showMoreSimilarButtonVisible = false;
                      }
                  })
 

--- a/assets/vue/ImageInfo.vue
+++ b/assets/vue/ImageInfo.vue
@@ -126,16 +126,16 @@
              url.addQuery("offset", this.similiarImages.length);
 
              fetch(url)
-                 .then(resp => {
-                     resp.json().then(jsonResp => {
-                         this.similiarImages = _.concat(this.similiarImages, jsonResp.images);
+                 .then(resp => resp.json())
+                 .then(jsonResp => {
+                     this.similiarImages = _.concat(this.similiarImages, jsonResp.images);
 
-                         // FIXME: make configurable
-                         if (jsonResp.images.length < 25) {
-                             this.showMoreSimiliarButtonVisible = false;
-                         }
-                     })
+                     // FIXME: make configurable
+                     if (jsonResp.images.length < 25) {
+                         this.showMoreSimiliarButtonVisible = false;
+                     }
                  })
+
          }
      }
  }

--- a/assets/vue/ImageInfo.vue
+++ b/assets/vue/ImageInfo.vue
@@ -39,6 +39,22 @@
         <a v-bind:href="image.image">
             <img class="img-fluid" v-bind:src="image.image" />
         </a>
+
+        <div class="container-fluid">
+            <div class="row">
+                <div class="card col-lg-6 col-xl-4" v-for="simage in similiarImages" v-bind:key="simage._id">
+                    <!-- Hacky but works! Looks beter then object-fit too  -->
+                    <!-- Just using the first "from" may not be the best idea -->
+                    <a v-bind:href="`/image/${simage._id}`">
+                        <div class="card-img-top img-card" v-bind:style="{backgroundImage: `url(${simage.image})`}"></div>
+                    </a>
+                </div>
+            </div>
+        </div>
+
+        <button class="btn btn-primary mx-auto" style="width: 15em;" v-bind:style="{ display: showMoreSimiliarButtonVisible ? 'block' : 'none' }" v-on:click="loadMoreSimiliar">
+            Similiar images
+        </button>
     </div>
 </template>
 
@@ -58,6 +74,13 @@
              type: Boolean,
              required: true
          }
+     },
+
+     data() {
+         return {
+             similiarImages: [],
+             showMoreSimiliarButtonVisible: true
+         };
      },
 
      computed: {
@@ -96,7 +119,40 @@
 
          unescapeTag(tag) {
              return he.decode(tag);
+         },
+
+         loadMoreSimiliar() {
+             let url = new URI(`/api/v1/similiar_images/${this.image._id}`);
+             url.addQuery("offset", this.similiarImages.length);
+
+             fetch(url)
+                 .then(resp => {
+                     resp.json().then(jsonResp => {
+                         this.similiarImages = _.concat(this.similiarImages, jsonResp.images);
+
+                         // FIXME: make configurable
+                         if (jsonResp.images.length < 25) {
+                             this.showMoreSimiliarButtonVisible = false;
+                         }
+                     })
+                 })
          }
      }
  }
 </script>
+
+<style>
+ .card-columns {
+     column-count: 5;
+     max-width: 100%;
+ }
+
+ .img-card {
+     height: 30em;
+     width: auto;
+     position: relative;
+     background-position: 50% 50%;
+     background-repeat: no-repeat;
+     background-size: cover;
+ }
+</style>

--- a/assets/vue/ImageModal.vue
+++ b/assets/vue/ImageModal.vue
@@ -31,3 +31,9 @@
      components: { ImageInfo }
  }
 </script>
+
+<style>
+ .modal-lg {
+     max-width: 80%;
+ }
+</style>

--- a/assets/vue/Index.vue
+++ b/assets/vue/Index.vue
@@ -75,28 +75,27 @@
              }
 
              fetch(imagesUrl)
-                 .then(resp => {
-                     resp.json().then(r => {
-                         this.images = r.result.images;
+                 .then(resp => resp.json())
+                 .then(r => {
+                     this.images = r.result.images;
 
-                         // Get a `range` of elements around the `index`
-                         function getAround(array, index, range) {
-                             var least = index - range - 1;
-                             least = (least < 0) ? 0 : least;
-                             return _.slice(array, least, least + (range * 2) + 1);
-                         }
+                     // Get a `range` of elements around the `index`
+                     function getAround(array, index, range) {
+                         var least = index - range - 1;
+                         least = (least < 0) ? 0 : least;
+                         return _.slice(array, least, least + (range * 2) + 1);
+                     }
 
 
-                         this.pages = getAround(
-                             _.range(1, Math.floor(r.result.imageCount / 25)), // FIXME: make page size configurable
-                             page,
-                             5
-                         );
+                     this.pages = getAround(
+                         _.range(1, Math.floor(r.result.imageCount / 25)), // FIXME: make page size configurable
+                         page,
+                         5
+                     );
 
-                         // Go to the top of the page
-                         window.scroll(0, 0);
-                     });
-                 })
+                     // Go to the top of the page
+                     window.scroll(0, 0);
+                 });
          },
 
          computePageUrl(page) {
@@ -115,11 +114,10 @@
          let queryUrl = new URI(window.location);
 
          fetch("/api/v1/imboard_info")
-             .then(resp => {
-                 resp.json().then(boards => {
-                     _.forEach(boards, (board) => {
-                         Vue.set(this.imboard_info, board._id, _.omit(board, "_id"));
-                     })
+             .then(resp => resp.json)
+             .then(boards => {
+                 _.forEach(boards, (board) => {
+                     Vue.set(this.imboard_info, board._id, _.omit(board, "_id"));
                  })
              })
              .then(this.updateImagesFromQueryString)

--- a/assets/vue/TopPanel.vue
+++ b/assets/vue/TopPanel.vue
@@ -12,34 +12,72 @@
                    value="Search" />
             <input class="btn btn-light form-control mx-2"
                    type="button" value="Help"
-                   data-toggle="collapse" data-target="#search-help-content" />
-            <div class="collapse mt-3" id="search-help-content">
-                <table class="table">
-                    <thead>
-                        <tr>
-                            <th scope="col">Syntax</th>
-                            <th scope="col">Meaning</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <th scope="row">tag</th>
-                            <td>Include the tag</td>
-                        </tr>
-                        <tr>
-                            <th scope="row">-tag</th>
-                            <td>Exclude the tag</td>
-                        </tr>
-                        <tr>
-                            <th scope="row">regex~tag_regex~</th>
-                            <td>
-                                Search tags by a regular expression.
-                                Note, that the regular expression <b>cannot</b> contant
-                                a tilde (that would end the tag)
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+                   data-toggle="modal" data-target="#search-help-modal" />
+            <div class="modal fade" role="dialog" tabIndex="-1" id="search-help-modal">
+                <div class="modal-dialog modal-lg" role="document">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title">Search help</h5>
+                        </div>
+                        <div class="modal-body">
+                            Note, that tags without logical operators are implicitly AND'ed.
+
+                            <br><br>
+
+                            <table class="table">
+                                <thead>
+                                    <tr>
+                                        <th scope="col">Syntax</th>
+                                        <th scope="col">Meaning</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th scope="row">tag</th>
+                                        <td>
+                                            Include a simple tag. This tag cannot contain none of the following symbols: <b>( ) - | &</b> or <b>\</b>.
+                                            If you want to use those symbols, you'll need to use the "exact" tag form.
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">"tag"</th>
+                                        <td>
+                                            Include an exact tag. This tag can contain any symbols, the <b>"</b> symbol can be
+                                            escaped as <b>\"</b>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">!tag</th>
+                                        <td>
+                                            Logically negate any tag, which basically means exclude it by some condition, which can
+                                            not only be the full tag, but e.g. a regular expression or a tag group.
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">REGEX(tag_regex)</th>
+                                        <td>
+                                            Search tags by a regular expression. Note, that the ")" symbol
+                                            can be escaped as \).
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">(tag1 tag2)</th>
+                                        <td>
+                                            Tag group. Groups several tags together to make logical operators work on all of them.
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">tag1 && tag2 <i>and</i> tag1 || tag2 </th>
+                                        <td>
+                                            Logical operators that combine tags. && means AND, || means OR. Any tag type
+                                            can be used with them, including tag groups and excluded tags.
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
             </div>
         </form>
     </nav>

--- a/conf/apiv1.routes
+++ b/conf/apiv1.routes
@@ -1,10 +1,13 @@
 # Images list
-GET     /images          controllers.apiv1.APIv1Controller.images(query: Option[String] ?= None, offset: Int ?= 0, limit: Int ?= 25)
+GET     /images               controllers.apiv1.APIv1Controller.images(query: Option[String] ?= None, offset: Int ?= 0, limit: Int ?= 25)
 
 # A single image
-GET     /image/:id       controllers.apiv1.APIv1Controller.image(id: String)
+GET     /image/:id            controllers.apiv1.APIv1Controller.image(id: String)
+
+# Similiar images
+GET     /similiar_images/:id  controllers.apiv1.APIv1Controller.similiar_images(id: String, offset: Int ?= 0, limit: Int ?= 25)
 
 # Imageboard info
-GET     /imboard_info    controllers.apiv1.APIv1Controller.imboard_info(name: Option[String] = None)
+GET     /imboard_info         controllers.apiv1.APIv1Controller.imboard_info(name: Option[String] = None)
 
-GET     /admin_panel_socket controllers.apiv1.APIv1Controller.admin_panel_socket
+GET     /admin_panel_socket   controllers.apiv1.APIv1Controller.admin_panel_socket

--- a/conf/apiv1.routes
+++ b/conf/apiv1.routes
@@ -4,8 +4,8 @@ GET     /images               controllers.apiv1.APIv1Controller.images(query: Op
 # A single image
 GET     /image/:id            controllers.apiv1.APIv1Controller.image(id: String)
 
-# Similiar images
-GET     /similiar_images/:id  controllers.apiv1.APIv1Controller.similiar_images(id: String, offset: Int ?= 0, limit: Int ?= 25)
+# Similar images
+GET     /similar_images/:id  controllers.apiv1.APIv1Controller.similar_images(id: String, offset: Int ?= 0, limit: Int ?= 25)
 
 # Imageboard info
 GET     /imboard_info         controllers.apiv1.APIv1Controller.imboard_info(name: Option[String] = None)

--- a/test/search/QueryParserSpec.scala
+++ b/test/search/QueryParserSpec.scala
@@ -2,51 +2,115 @@ package soxx.search
 
 import org.scalatest._
 
-import QueryParser.{ parseQuery, Success }
-
-class QueryParserSpec extends FlatSpec with Matchers with Inside {
+class QueryParserSpec extends FlatSpec with Matchers with LoneElement {
   behavior of "A query parser"
 
-  it should "return a FullTag when one is given" in {
-    inside(parseQuery("test_tag")) { case Success(List(FullTag(matched)), _) =>
-      matched shouldEqual "test_tag"
-    }
+  def parse(query: String) = {
+    import QueryParser.{ parseQuery, Success }
+
+    val r = parseQuery(query)
+
+    r shouldBe a [Success[_]]
+
+    r.get
   }
 
-  it should "return an ExcludeTag when give a tag with a minus in the beginning" in {
-    inside(parseQuery("-test_tag")) { case Success(List(ExcludeTag(matched)), _) =>
-      matched shouldEqual "test_tag"
-    }
+  it should "parse a simple tag" in {
+    parse("test_tag").loneElement shouldBe SimpleTag("test_tag")
   }
 
-  it should "return a RegexTag when given a regex~" in {
-    inside(parseQuery("regex~\\d~")) { case Success(List(RegexTag(matched)), _) =>
-      matched.regex shouldEqual "\\d"
-    }
+  it should "prase the NOT marker" in {
+    val r = parse(""" !test_tag !"\"_\"" """)
+    r should have length 2
+
+    r(0) shouldBe TagNOT(SimpleTag("test_tag"))
+    r(1) shouldBe TagNOT(ExactTag("\"_\""))
   }
 
-  it should "parse multiple tags separated with spaces" in {
-    inside(parseQuery("-test_1 test_2 regex~\\d~")) {
-      case Success(List(ExcludeTag(excl), FullTag(fl), RegexTag(matched)), _) =>
-        excl shouldEqual "test_1"
-        fl shouldEqual "test_2"
-        matched.regex shouldEqual "\\d"
-    }
+  it should "parse an exact tag" in {
+    parse("\"test_(exact_1)\"").loneElement shouldBe ExactTag("test_(exact_1)")
+  }
+
+  it should "parse a REGEX tag" in {
+    val r = parse("""REGEX(test_\(\d+\\))""")
+    r.head shouldBe a [RegexTag]
+
+    val rt = r.head.asInstanceOf[RegexTag]
+
+    rt.value.regex shouldBe """test_\(\d+\)"""
+  }
+
+  it should "parse multiple different tags separated with spaces" in {
+    val r = parse("""!test_1 test_2 "tag_3_(test)" REGEX(test_\(\d+\\))""")
+    r should have length 4
+
+    r(0) shouldBe TagNOT(SimpleTag("test_1"))
+    r(1) shouldBe SimpleTag("test_2")
+    r(2) shouldBe ExactTag("tag_3_(test)")
+
+    r(3) shouldBe a [RegexTag]
+    r(3).asInstanceOf[RegexTag].value.regex shouldBe """test_\(\d+\)"""
+
   }
 
   it should "return an empty list when there are no tags" in {
-    inside(parseQuery("")) { case Success(result, _) =>
-      result.length shouldEqual 0
-    }
+    parse("") shouldBe empty
   }
 
   it should "recognize symbols in tags" in {
-    inside(parseQuery("some_body~ once_told_me_! -the_world_is_(gonna) regex~roll-me...~")) {
-      case Success(List(FullTag(fst), FullTag(snd), ExcludeTag(excl), RegexTag(smb)), _) =>
-        fst shouldEqual "some_body~"
-        snd shouldEqual "once_told_me_!"
-        excl shouldEqual "the_world_is_(gonna)"
-        smb.regex shouldEqual "roll-me..."
-    }
+    val r = parse("some_body~ once_told_me_@ !\"the_world_is_(gonna)\"")
+    r should have length 3
+
+    r(0) shouldBe SimpleTag("some_body~")
+    r(1) shouldBe SimpleTag("once_told_me_@")
+    r(2) shouldBe TagNOT(ExactTag("the_world_is_(gonna)"))
+  }
+
+  it should "group all kinds of tags" in {
+    val r = parse("""(i_aint !the_sharpest_tool~ "in_the_shed_(huh)" REGEX(test_\(\d+\\))) some_more_testing""")
+    r should have length 2
+
+    r(0) shouldBe a [TagGroup]
+    val gr = r(0).asInstanceOf[TagGroup].value
+    gr should have length 4
+
+    gr(0) shouldBe SimpleTag("i_aint")
+    gr(1) shouldBe TagNOT(SimpleTag("the_sharpest_tool~"))
+    gr(2) shouldBe ExactTag("in_the_shed_(huh)")
+
+    gr(3) shouldBe a [RegexTag]
+    gr(3).asInstanceOf[RegexTag].value.regex shouldBe """test_\(\d+\)"""
+
+    r(1) shouldBe SimpleTag("some_more_testing")
+  }
+
+  it should "parse AND as left associative" in {
+    parse("a && b && c").loneElement shouldBe TagAND(TagAND(SimpleTag("a"), SimpleTag("b")), SimpleTag("c"))
+  }
+
+  it should "parse OR as left associative" in {
+    parse("a || b || c").loneElement shouldBe TagOR(TagOR(SimpleTag("a"), SimpleTag("b")), SimpleTag("c"))
+  }
+
+  it should "parse complex logic operations" in {
+    val r = parse("(a && !b) || (!c d)").head
+    r shouldBe a [TagOR]
+
+    val to = r.asInstanceOf[TagOR]
+
+    to.left shouldBe a [TagGroup]
+    val lh = to.left.asInstanceOf[TagGroup].value
+    lh(0) shouldBe a [TagAND]
+    val lha = lh(0).asInstanceOf[TagAND]
+
+    lha.left shouldBe SimpleTag("a")
+    lha.right shouldBe TagNOT(SimpleTag("b"))
+
+    to.right shouldBe a [TagGroup]
+    val rh = to.right.asInstanceOf[TagGroup].value
+
+    rh(0) shouldBe TagNOT(SimpleTag("c"))
+    rh(1) shouldBe SimpleTag("d")
+
   }
 }


### PR DESCRIPTION
Some symbols are now prohibited from "simple" (previously know as "full")
tags. To write those symbols one needs to use an "exact" tag, where
any symbols can be used.

Exluding tags is now reaplced with logical NOT which works on everything.

Tags can now be grouped with parenthesis. This is particularly useful
when using logical statements like && (AND) and || (OR) to create
complex logical statements. Both && and || are left associative operators.

Regex tag is now written as REGEX(actual regex), closing parens must
be escaped as \). In addition, they are now represented as JS regexes
in the search query.

Test should cover most of use cases for these tags, but there still
might be some corner cases.

MongoDB query generation is not well tested, but should work as
expected since there is nothing too complex there.

The search manual is also reworked and is now a modal, because there's a lot of stuff there.